### PR TITLE
Fix typo in install directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gulp.task('to-png', function() {
 To use this, you'll need `pdftocairo` installed, which can probably be installed with a package manager. Currently left as an exercise for the reader.
 
 ```sh
-$ npm install gulp-pdtocairo
+$ npm install gulp-pdftocairo
 ```
 
 


### PR DESCRIPTION
Was `npm install gulp-pdtocairo` should be `npm install gulp-pdftocairo`. This
typo also exists the [NPM package webpage](https://www.npmjs.com/package/gulp-pdftocairo)
